### PR TITLE
Add LRU cache option

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -5,7 +5,7 @@ name = "go"
 enabled = true
 
   [analyzers.meta]
-  import_root = "github.com/krakendio/krakend-cors"
+  import_root = "github.com/krakendio/krakend-httpcache/v2"
 
 [[transformers]]
 name = "gofmt"

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/krakendio/krakend-httpcache/v2
 
-go 1.17
+go 1.22
 
 require (
+	github.com/krakend/lru v0.0.0-20250121172718-0e3a6eab620d
 	github.com/krakendio/httpcache v0.0.0-20221129153752-65a87a5c2bc5
 	github.com/luraproject/lura/v2 v2.2.3
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
+github.com/krakend/lru v0.0.0-20250121172718-0e3a6eab620d h1:Kktd6hjWjY+TgL/oESBdTTVKJ7BFroS/YA2PZ1PsFLA=
+github.com/krakend/lru v0.0.0-20250121172718-0e3a6eab620d/go.mod h1:VgOve4vVYbY6UkD3qHdqmq2AKwqHlp39TKMi2b2cQBI=
 github.com/krakendio/flatmap v1.1.1 h1:rGBNVpBY0pMk6cLOwerVzoKY4HELnpu0xvqB231lOCQ=
 github.com/krakendio/flatmap v1.1.1/go.mod h1:KBuVkiH5BcBFRa5A1HdSHDn8a8LzsyRTKZArX0vqTbo=
 github.com/krakendio/httpcache v0.0.0-20221129153752-65a87a5c2bc5 h1:gB5divkol6FZK6OVGjh7odTsOY3FAESpeq9qyAVCZkc=
 github.com/krakendio/httpcache v0.0.0-20221129153752-65a87a5c2bc5/go.mod h1:VWTP3MZHr/W9OauBMrOQ2bD1rIjDetAQo5JbXCezYKE=
-github.com/luraproject/lura/v2 v2.0.5 h1:Mc4uj37s7mv6qRLy+Uo983CiaITPSVJYooeUilbiD+k=
-github.com/luraproject/lura/v2 v2.0.5/go.mod h1:r2N4j89Snm1j+Y9CCa9cYR1T2ETRL0E4y9P+DgymqX4=
 github.com/luraproject/lura/v2 v2.2.3 h1:zePcqPP7XXjDKmWht8hJbFoPVNtBgdV3I6F2PyTFaB8=
 github.com/luraproject/lura/v2 v2.2.3/go.mod h1:Outo/8O5zqa2itP1wD/mdD5nskjo09R74EbMVgr1L98=
 github.com/valyala/fastrand v1.1.0 h1:f+5HkLW4rsgzdNoleUOB69hyT9IlD2ZQh9GyDMfb5G8=

--- a/http.go
+++ b/http.go
@@ -84,8 +84,10 @@ func selectCache(opts options) Cache {
 	return globalLruCache
 }
 
-var globalLruCache Cache
-var globalCache = httpcache.NewMemoryCache()
+var (
+	globalLruCache Cache
+	globalCache    = httpcache.NewMemoryCache()
+)
 
 type options struct {
 	Shared   bool   `json:"shared"`

--- a/http_test.go
+++ b/http_test.go
@@ -21,100 +21,217 @@ import (
 
 var maxRequests = 100
 
-func TestClient_shared(t *testing.T) {
-	globalCache = httpcache.NewMemoryCache()
-	defer func() { globalCache = nil }()
+func tearDown() {
+	globalCache = nil
+	globalLruCache = nil
+}
 
-	cfg := &config.Backend{
-		Decoder: encoding.JSONDecoder,
-		ExtraConfig: map[string]interface{}{
-			Namespace: map[string]interface{}{
+func TestClient_shared(t *testing.T) {
+	testCases := []struct {
+		Name string
+		Cfg  map[string]interface{}
+	}{
+		{
+			Name: "shared memory cache",
+			Cfg: map[string]interface{}{
 				"shared": true,
 			},
 		},
+		{
+			Name: "shared LRU cache",
+			Cfg: map[string]interface{}{
+				"shared":    true,
+				"max_items": 10,
+				"max_size":  100000,
+			},
+		},
 	}
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			globalCache = httpcache.NewMemoryCache()
+			defer tearDown()
 
-	b := newBackend(300)
-	defer b.Close()
+			cfg := &config.Backend{
+				Decoder: encoding.JSONDecoder,
+				ExtraConfig: map[string]interface{}{
+					Namespace: testCase.Cfg,
+				},
+			}
 
-	testClient(t, cfg, b.URL())
-	testClient(t, cfg, b.URL())
-	testClient(t, cfg, b.URL())
-	testClient(t, cfg, b.URL())
+			b := newBackend(300)
+			defer b.Close()
 
-	if hits := b.Count(); hits != 1 {
-		t.Errorf("unexpected number of hits. got: %d, want: 1", hits)
+			testClient(t, cfg, b.URL(), maxRequests)
+			testClient(t, cfg, b.URL(), maxRequests)
+			testClient(t, cfg, b.URL(), maxRequests)
+			testClient(t, cfg, b.URL(), maxRequests)
+
+			if hits := b.Count(); hits != 1 {
+				t.Errorf("unexpected number of hits. got: %d, want: 1", hits)
+			}
+		})
 	}
 }
 
 func TestClient_refresh(t *testing.T) {
+	testCases := []struct {
+		Name string
+		Cfg  map[string]interface{}
+	}{
+		{
+			Name: "shared memory cache",
+			Cfg: map[string]interface{}{
+				"shared": true,
+			},
+		},
+		{
+			Name: "dedicated memory cache",
+			Cfg: map[string]interface{}{
+				"shared": false,
+			},
+		},
+		{
+			Name: "shared LRU cache",
+			Cfg: map[string]interface{}{
+				"shared":    true,
+				"max_items": 10,
+				"max_size":  100000,
+			},
+		},
+		{
+			Name: "dedicated LRU cache",
+			Cfg: map[string]interface{}{
+				"shared":    false,
+				"max_items": 10,
+				"max_size":  100000,
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			globalCache = httpcache.NewMemoryCache()
+			defer tearDown()
+
+			cfg := &config.Backend{
+				Decoder: encoding.JSONDecoder,
+				ExtraConfig: map[string]interface{}{
+					Namespace: testCase.Cfg,
+				},
+			}
+
+			b := newBackend(1)
+			defer b.Close()
+
+			testClient(t, cfg, b.URL(), maxRequests)
+			<-time.After(1500 * time.Millisecond)
+			testClient(t, cfg, b.URL(), maxRequests)
+			<-time.After(1500 * time.Millisecond)
+			testClient(t, cfg, b.URL(), maxRequests)
+
+			if hits := b.Count(); hits != 3 {
+				t.Errorf("unexpected number of hits. got: %d, want: 3", hits)
+			}
+		})
+	}
+}
+
+func TestClient_dedicated(t *testing.T) {
+	testCases := []struct {
+		Name string
+		Cfg  map[string]interface{}
+	}{
+		{
+			Name: "dedicated memory cache",
+			Cfg: map[string]interface{}{
+				"shared": false,
+			},
+		},
+		{
+			Name: "dedicated LRU cache",
+			Cfg: map[string]interface{}{
+				"shared":    false,
+				"max_items": 10,
+				"max_size":  100000,
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			globalCache = httpcache.NewMemoryCache()
+			defer tearDown()
+
+			b := newBackend(300)
+			defer b.Close()
+
+			{
+				cfg := &config.Backend{
+					Decoder: encoding.JSONDecoder,
+					ExtraConfig: map[string]interface{}{
+						Namespace: testCase.Cfg,
+					},
+				}
+
+				testClient(t, cfg, b.URL(), maxRequests)
+
+				if hits := b.Count(); hits != 1 {
+					t.Errorf("unexpected number of hits. got: %d, want: 1", hits)
+				}
+			}
+
+			{
+				cfg := &config.Backend{
+					Decoder: encoding.JSONDecoder,
+					ExtraConfig: map[string]interface{}{
+						Namespace: map[string]interface{}{},
+					},
+				}
+
+				testClient(t, cfg, b.URL(), maxRequests)
+
+				if hits := b.Count(); hits != 2 {
+					t.Errorf("unexpected number of hits. got: %d, want: 2", hits)
+				}
+			}
+		})
+	}
+}
+
+func TestClient_lruEvictions(t *testing.T) {
 	globalCache = httpcache.NewMemoryCache()
-	defer func() { globalCache = nil }()
+	defer tearDown()
+
+	// Each backend response is around 180 bytes
+	b1 := newBackend(300)
+	b2 := newBackend(300)
+	defer b1.Close()
+	defer b2.Close()
 
 	cfg := &config.Backend{
 		Decoder: encoding.JSONDecoder,
 		ExtraConfig: map[string]interface{}{
 			Namespace: map[string]interface{}{
-				"shared": true,
+				"shared":    true,
+				"max_items": 100,
+				"max_size":  250, // Only one backend response will fit in the cache
 			},
 		},
 	}
 
-	b := newBackend(1)
-	defer b.Close()
+	testClient(t, cfg, b1.URL(), 1) // LRU size increases ~180 bytes
+	testClient(t, cfg, b2.URL(), 1) // LRU size increases ~180 bytes, evicts previous entry
+	testClient(t, cfg, b1.URL(), 1) // Should hit backend
 
-	testClient(t, cfg, b.URL())
-	<-time.After(1500 * time.Millisecond)
-	testClient(t, cfg, b.URL())
-	<-time.After(1500 * time.Millisecond)
-	testClient(t, cfg, b.URL())
-
-	if hits := b.Count(); hits != 3 {
-		t.Errorf("unexpected number of hits. got: %d, want: 3", hits)
+	if hits := b1.Count(); hits != 2 {
+		t.Errorf("unexpected number of hits. got: %d, want: 2", hits)
 	}
-}
-
-func TestClient_dedicated(t *testing.T) {
-	globalCache = httpcache.NewMemoryCache()
-	defer func() { globalCache = nil }()
-
-	b := newBackend(300)
-	defer b.Close()
-
-	{
-		cfg := &config.Backend{
-			Decoder: encoding.JSONDecoder,
-			ExtraConfig: map[string]interface{}{
-				Namespace: false,
-			},
-		}
-
-		testClient(t, cfg, b.URL())
-
-		if hits := b.Count(); hits != 1 {
-			t.Errorf("unexpected number of hits. got: %d, want: 1", hits)
-		}
-	}
-
-	{
-		cfg := &config.Backend{
-			Decoder: encoding.JSONDecoder,
-			ExtraConfig: map[string]interface{}{
-				Namespace: map[string]interface{}{},
-			},
-		}
-
-		testClient(t, cfg, b.URL())
-
-		if hits := b.Count(); hits != 2 {
-			t.Errorf("unexpected number of hits. got: %d, want: 2", hits)
-		}
+	if hits := b2.Count(); hits != 1 {
+		t.Errorf("unexpected number of hits. got: %d, want: 1", hits)
 	}
 }
 
 func TestClient_noCache(t *testing.T) {
 	globalCache = httpcache.NewMemoryCache()
-	defer func() { globalCache = nil }()
+	defer tearDown()
 
 	b := newBackend(300)
 	defer b.Close()
@@ -124,7 +241,7 @@ func TestClient_noCache(t *testing.T) {
 		ExtraConfig: map[string]interface{}{},
 	}
 
-	testClient(t, cfg, b.URL())
+	testClient(t, cfg, b.URL(), maxRequests)
 
 	if hits := b.Count(); hits != uint64(maxRequests) {
 		t.Errorf("unexpected number of hits. got: %d, want: %d", hits, uint64(maxRequests))
@@ -133,7 +250,7 @@ func TestClient_noCache(t *testing.T) {
 
 func TestClient_backendFactory(t *testing.T) {
 	globalCache = httpcache.NewMemoryCache()
-	defer func() { globalCache = nil }()
+	defer tearDown()
 
 	b := newBackend(300)
 	defer b.Close()
@@ -173,10 +290,10 @@ func TestClient_backendFactory(t *testing.T) {
 	}
 }
 
-func testClient(t *testing.T, cfg *config.Backend, URL string) {
+func testClient(t *testing.T, cfg *config.Backend, URL string, numRequests int) {
 	c := NewHTTPClient(cfg, client.NewHTTPClient)(context.Background())
 
-	for i := 0; i < maxRequests; i++ {
+	for i := 0; i < numRequests; i++ {
 		resp, err := c.Get(URL)
 		if err != nil {
 			t.Error(err)

--- a/http_test.go
+++ b/http_test.go
@@ -316,7 +316,7 @@ const statusOKMsg = `{"status": "ok"}`
 func newBackend(ttl int) backend {
 	var ops uint64
 	return backend{
-		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			atomic.AddUint64(&ops, 1)
 			w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", ttl))
 			w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
Adding a new cache option using a [custom LRU implementation ](https://github.com/krakend/lru)

Now the `qos/http-cache` accepts two additional parameters that will enable the LRU cache:

* `max_size`: number of bytes LRU cache will store before evictions
* `max_items`: number of entries LRU cache will store before evictions

Both of them are required, if they are missing, we fallback to the current memory cache implementation

It also accepts the `shared` flag to globally store entries among backend